### PR TITLE
feat: add future group for easier multiple wait

### DIFF
--- a/async/go.mod
+++ b/async/go.mod
@@ -1,0 +1,5 @@
+module github.com/wdhongtw/mice/async
+
+go 1.18
+
+require golang.org/x/sync v0.2.0

--- a/async/go.sum
+++ b/async/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/async/group.go
+++ b/async/group.go
@@ -1,0 +1,48 @@
+package async
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type FutureFunc[T any] func(ctx context.Context) (T, error)
+
+// FutureGroup is a container that collect execution result from multiple jobs.
+type FutureGroup[T any] struct {
+	jobs []FutureFunc[T]
+}
+
+// NewGroup create a FutureGroup
+func NewGroup[T any]() *FutureGroup[T] {
+	return &FutureGroup[T]{}
+}
+
+// Go registers a job that produce a T on success.
+//
+// The job is called with a context, which is cancelled automatically if some other job return error.
+func (rg *FutureGroup[T]) Go(job FutureFunc[T]) {
+	rg.jobs = append(rg.jobs, job)
+}
+
+// Wait blocks wait until all jobs complete, returns results and the first error (if any).
+//
+// Just like sync.WaitGroup and errgroup.Group,
+// caller should Add/Launch job and Wait in the same goroutine.
+func (rg *FutureGroup[T]) Wait(ctx context.Context) ([]T, error) {
+	result := make([]T, len(rg.jobs))
+	group, ctx := errgroup.WithContext(ctx)
+	for idx, job := range rg.jobs {
+		idx, job := idx, job
+		group.Go(func() error {
+			t, err := job(ctx)
+
+			// safe concurrent assess to allocated slice, tested with go test -race
+			result[idx] = t
+			return err
+		})
+	}
+
+	err := group.Wait()
+	return result, err
+}

--- a/async/group_test.go
+++ b/async/group_test.go
@@ -1,0 +1,111 @@
+package async
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestFutureGroup(t *testing.T) {
+	t.Run("GetResultFromAllJobs", func(t *testing.T) {
+		rg := NewGroup[int]()
+		rg.Go(func(_ context.Context) (int, error) {
+			return 1, nil
+		})
+		rg.Go(func(_ context.Context) (int, error) {
+			time.Sleep(1 * time.Millisecond)
+			return 2, nil
+		})
+
+		result, err := rg.Wait(context.Background())
+		if err != nil {
+			t.Errorf("wait return error: %v", err)
+		}
+		if !sliceElemEqual([]int{1, 2}, result) {
+			t.Errorf("expected: %v, got %v", []int{1, 2}, result)
+		}
+	})
+	t.Run("PartialErrorCauseFinalError", func(t *testing.T) {
+		rg := NewGroup[any]()
+		rg.Go(func(_ context.Context) (any, error) {
+			return nil, nil
+		})
+		rg.Go(func(_ context.Context) (any, error) {
+			return nil, fmt.Errorf("some-error")
+		})
+
+		_, err := rg.Wait(context.Background())
+		if err == nil {
+			t.Errorf("wait return no error")
+		}
+	})
+	t.Run("EmptyJobsListWorksFine", func(t *testing.T) {
+		rg := NewGroup[string]()
+
+		result, err := rg.Wait(context.Background())
+		if err != nil {
+			t.Errorf("wait return error: %v", err)
+		}
+		if !sliceElemEqual([]string{}, result) {
+			t.Errorf("expected: %v, got %v", []string{}, result)
+		}
+	})
+}
+
+func BenchmarkFutureGroup(b *testing.B) {
+	b.Run("FourStringJobSuccess", func(b *testing.B) {
+		expected := []string{"", "", "", ""}
+		ctx := context.Background()
+		for i := 0; i < b.N; i++ {
+			rg := NewGroup[string]()
+			for i := 0; i < 4; i++ {
+				rg.Go(func(ctx context.Context) (string, error) {
+					return "", nil
+				})
+			}
+
+			result, err := rg.Wait(ctx)
+			if err != nil {
+				b.Errorf("wait return error: %v", err)
+			}
+
+			if !sliceElemEqual(expected, result) {
+				b.Errorf("expected: %v, got %v", expected, result)
+			}
+		}
+	})
+	b.Run("FourAnyJobError", func(b *testing.B) {
+		ctx := context.Background()
+		for i := 0; i < b.N; i++ {
+			rg := NewGroup[any]()
+			rg.Go(func(ctx context.Context) (any, error) {
+				return nil, fmt.Errorf("some-error")
+			})
+			for i := 0; i < 4; i++ {
+				rg.Go(func(ctx context.Context) (any, error) {
+					return nil, nil
+				})
+			}
+
+			_, err := rg.Wait(ctx)
+			if err == nil {
+				b.Errorf("wait return no error")
+			}
+		}
+	})
+}
+
+func sliceElemEqual[T comparable](left, right []T) bool {
+	leftMap := map[T]struct{}{}
+	rightMap := map[T]struct{}{}
+
+	for _, item := range left {
+		leftMap[item] = struct{}{}
+	}
+	for _, item := range right {
+		rightMap[item] = struct{}{}
+	}
+	return reflect.DeepEqual(leftMap, rightMap)
+}


### PR DESCRIPTION
- Like JS Promise.all and Python TaskGroup, do early cancellation.
- Use generic feature, provide a type-safe API.